### PR TITLE
Support for the additional apiv2 fields and address details

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.x']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [pull_request]
+on:  
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -12,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -19,21 +24,25 @@ jobs:
         cache: pip
         cache-dependency-path: |
           requirements*.txt
+          
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
+        
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        
     - name: Test with pytest
       run: |
-        pytest --cov=prismaEDL --cov-branch
+        pytest --cov=prismaEDL --cov-branch --cov-report=xml
+        
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,8 @@ name: Python package
 
 on:  
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,6 +46,5 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
-        directory: ./coverage/reports/
         env_vars: OS,PYTHON
         flags: unittests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Main Workflow
 
 on:  
   push:
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,17 +35,17 @@ jobs:
         
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         
     - name: Test with pytest
       run: |
-        pytest --cov=prismaEDL --cov-branch --cov-report=xml
+        pytest --cov=./ --cov-branch --cov-report=xml
         
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
-        verbose: true
+        directory: ./coverage/reports/
+        env_vars: OS,PYTHON
+        flags: unittests

--- a/prismaEDL/utilities.py
+++ b/prismaEDL/utilities.py
@@ -4,10 +4,12 @@ import requests
 
 PRISMA_API_URL = 'https://api.prod.datapath.prismaaccess.com/getPrismaAccessIP/v2'
 
-@dataclass()
+@dataclass
 class MobileIP:
     zone: str
-    addresses: List[str]
+    address: str
+    status: str
+    type: str
 
 def get_mobile_ips(api_key):
     data = {
@@ -23,7 +25,12 @@ def get_mobile_ips(api_key):
         if result['status'] == 'success':
             mobile_ips = []
             for entry in result['result']:
-                mobile_ips.append(MobileIP(zone=entry['zone'], addresses=entry['addresses']))
+                zone = entry['zone']
+                for details in entry['address_details']:
+                    address = details['address']
+                    status = details['addressType']
+                    type = details['serviceType']
+                    mobile_ips.append(MobileIP(zone=zone, address=address, status=status, type=type))
             return mobile_ips
     except KeyError:
         raise RuntimeError(result)

--- a/prismaEDL/views.py
+++ b/prismaEDL/views.py
@@ -14,4 +14,4 @@ def palo_edl():
         for address in mobile_ip.addresses:
             palo_format.append(f'{address} #{mobile_ip.zone}')
 
-    return Response('\r\n'.join(palo_format), mimetype='text/plaintext')
+    return Response('\n'.join(palo_format), mimetype='text/plaintext')

--- a/prismaEDL/views.py
+++ b/prismaEDL/views.py
@@ -11,7 +11,6 @@ def palo_edl():
     ip_data = get_mobile_ips(api_key)
     palo_format = []
     for mobile_ip in ip_data:
-        for address in mobile_ip.addresses:
-            palo_format.append(f'{address} #{mobile_ip.zone}')
+        palo_format.append(f'{mobile_ip.address} #{mobile_ip.zone} - {mobile_ip.status.upper()}')
 
     return Response('\n'.join(palo_format), mimetype='text/plaintext')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,7 +13,7 @@ def test_data_get_valid(requests_mock):
         json_data = infile.read()
     requests_mock.post(PRISMA_API_URL, text=json_data)
     expected = [
-        MobileIP(zone='Colombia', addresses=['101.1.2.4']),
+        MobileIP(zone='Colombia', addresses=['101.1.2.4', '101.2.3.4']),
         MobileIP(zone='Argentina', addresses=['101.1.2.5']),
         MobileIP(zone='Brazil Central', addresses=['101.1.2.3'])
     ]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,9 +13,10 @@ def test_data_get_valid(requests_mock):
         json_data = infile.read()
     requests_mock.post(PRISMA_API_URL, text=json_data)
     expected = [
-        MobileIP(zone='Colombia', addresses=['101.1.2.4', '101.2.3.4']),
-        MobileIP(zone='Argentina', addresses=['101.1.2.5']),
-        MobileIP(zone='Brazil Central', addresses=['101.1.2.3'])
+        MobileIP(zone='Colombia', address='101.1.2.4', status='active', type='gp_gateway'),
+        MobileIP(zone='Colombia', address='101.2.3.4', status='reserved', type='gp_gateway'),
+        MobileIP(zone='Argentina', address='101.1.2.5', status='active', type='gp_gateway'),
+        MobileIP(zone='Brazil Central', address='101.1.2.3', status='active', type='gp_gateway')
     ]
 
     result = get_mobile_ips(api_key="TestingKey")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -6,7 +6,8 @@ def get_path(file):
     path = os.path.join(os.path.dirname(__file__), file)
     return path
 
-def test_paloalto(requests_mock, client):
+
+def test_paloalto_basic(requests_mock, client):
     # SETUP
     with open(get_path('testfiles/happy_response.json')) as infile:
         fake_data = infile.read()
@@ -15,3 +16,17 @@ def test_paloalto(requests_mock, client):
     response = client.get(url_for('main.palo_edl'))
     assert b'101.1.2.4' in response.data
     assert requests_mock.called_once
+
+
+def test_paloalto_exact(requests_mock, client):
+    # SETUP
+    with open(get_path('testfiles/happy_response.json')) as infile:
+        fake_data = infile.read()
+    requests_mock.post(PRISMA_API_URL, text=fake_data)
+
+    response = client.get(url_for('main.palo_edl'))
+
+    with open(get_path('testfiles/prismaEDL_expected.txt')) as infile:
+        expected = infile.read()
+
+    assert response.text == expected

--- a/tests/testfiles/happy_response.json
+++ b/tests/testfiles/happy_response.json
@@ -3,7 +3,8 @@
   "result": [{
       "zone": "Colombia",
       "addresses": [
-        "101.1.2.4"
+        "101.1.2.4",
+        "101.2.3.4",
       ],
       "address_details": [{
         "address": "101.1.2.4",
@@ -11,6 +12,13 @@
         "addressType": "active",
         "create_time": 1683063866,
         "allow_listed": false
+      },
+      {
+        "address": "101.2.3.4",
+        "serviceType": "gp_gateway",
+        "addressType": "reserved",
+        "create_time": 1683063866,
+        "allow_listed": false,
       }]
     },
     {

--- a/tests/testfiles/happy_response.json
+++ b/tests/testfiles/happy_response.json
@@ -1,23 +1,43 @@
 {
   "status": "success",
-  "result": [
-    {
+  "result": [{
       "zone": "Colombia",
       "addresses": [
         "101.1.2.4"
-      ]
+      ],
+      "address_details": [{
+        "address": "101.1.2.4",
+        "serviceType": "gp_gateway",
+        "addressType": "active",
+        "create_time": 1683063866,
+        "allow_listed": false
+      }]
     },
     {
       "zone": "Argentina",
       "addresses": [
         "101.1.2.5"
-      ]
+      ],
+      "address_details": [{
+        "address": "101.1.2.5",
+        "serviceType": "gp_gateway",
+        "addressType": "active",
+        "create_time": 1683063866,
+        "allow_listed": false
+      }]
     },
     {
       "zone": "Brazil Central",
       "addresses": [
         "101.1.2.3"
-      ]
+      ],
+      "address_details": [{
+        "address": "101.1.2.3",
+        "serviceType": "gp_gateway",
+        "addressType": "active",
+        "create_time": 1683063866,
+        "allow_listed": false
+      }]
     }
   ]
 }

--- a/tests/testfiles/happy_response.json
+++ b/tests/testfiles/happy_response.json
@@ -4,7 +4,7 @@
       "zone": "Colombia",
       "addresses": [
         "101.1.2.4",
-        "101.2.3.4",
+        "101.2.3.4"
       ],
       "address_details": [{
         "address": "101.1.2.4",
@@ -18,7 +18,7 @@
         "serviceType": "gp_gateway",
         "addressType": "reserved",
         "create_time": 1683063866,
-        "allow_listed": false,
+        "allow_listed": false
       }]
     },
     {

--- a/tests/testfiles/prismaEDL_expected.txt
+++ b/tests/testfiles/prismaEDL_expected.txt
@@ -1,0 +1,4 @@
+101.1.2.4 #Colombia
+101.2.3.4 #Colombia
+101.1.2.5 #Argentina
+101.1.2.3 #Brazil Central

--- a/tests/testfiles/prismaEDL_expected.txt
+++ b/tests/testfiles/prismaEDL_expected.txt
@@ -1,4 +1,4 @@
-101.1.2.4 #Colombia
-101.2.3.4 #Colombia
-101.1.2.5 #Argentina
-101.1.2.3 #Brazil Central
+101.1.2.4 #Colombia - ACTIVE
+101.2.3.4 #Colombia - RESERVED
+101.1.2.5 #Argentina - ACTIVE
+101.1.2.3 #Brazil Central - ACTIVE


### PR DESCRIPTION
Palo's recommendations for what to allowlist have changed, in addition the data returned includes additional address details which are worthwhile to add to comments.